### PR TITLE
add clustering with Leaflet.markercluster

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,9 @@
     <link rel="stylesheet" href="css/font-awesome/css/font-awesome.min.css">
     <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico" />
     <script src="https://mapzen.com/js/mapzen.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/0.5.0/leaflet.markercluster.js"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/0.5.0/MarkerCluster.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/0.5.0/MarkerCluster.Default.css" />
     <script src="js/d3.v3.min.js"></script>
   </head>
   <body>

--- a/js/event-map.js
+++ b/js/event-map.js
@@ -1,6 +1,7 @@
 var eventsMap = function() {
   var map,
     markers = [],
+    markerGroup = L.markerClusterGroup(),
     keyIndex = -1,
     xhr,
     searchedLocation,
@@ -78,6 +79,7 @@ var eventsMap = function() {
     },
     addMarkers : function(features) {
       markers = [];
+      markerGroup.clearLayers()
       features.forEach(function(f){
         var marker = L.marker(L.latLng(f.locations[0].latitude, f.locations[0].longitude));
         marker.bindPopup(
@@ -88,8 +90,9 @@ var eventsMap = function() {
           +"</p><p class='rsvp'><a href='https://www.hillaryclinton.com/events/view/'"+f.lookupId+">rsvp</a></p>"
         );
         markers.push(marker);
-        marker.addTo(map);
       });
+      markerGroup.addLayers(markers);
+      map.addLayer(markerGroup);
 
       // zoom to fit markers if the "update map button" is unchecked
       if (document.getElementById('move-update').checked || !markers.length) return;


### PR DESCRIPTION
Use [Leaflet.markercluster](https://github.com/Leaflet/Leaflet.markercluster/tree/leaflet-0.7) to cluster markers and show a number, instead of lots of overlapping markers. This is especially useful when multiple events occur at the same location.  

<img width="544" alt="screen shot 2016-08-22 at 8 52 24 pm" src="https://cloud.githubusercontent.com/assets/1649528/17879929/763393e0-68aa-11e6-8de4-7fdcfad45e32.png">

Clicking on a cluster expands the pins within it.

<img width="506" alt="screen shot 2016-08-22 at 8 52 40 pm" src="https://cloud.githubusercontent.com/assets/1649528/17879935/82211bbe-68aa-11e6-8b04-2e36c494e946.png">
