### PR TITLE
Mobile card sizes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -434,7 +434,7 @@ html, body {
     display: none;
   }
   #detail {
-    height: 33%;
+    height: 40%;
     position: absolute;
     bottom: 0;
     display: none;

--- a/css/style.css
+++ b/css/style.css
@@ -441,4 +441,8 @@ html, body {
     background-color: #fff;
     overflow: scroll;
   }
+  .list-event .rsvp {
+    font-size:22px;
+    margin-left:12px;
+  }
 }


### PR DESCRIPTION
expand info card a bit to avoid overflow scroll in most cases
