### PR TITLE
make page appear faster

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,23 +4,15 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>HRC Events Near You</title>
+    <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico" />
     <meta property="og:site_name" content="DevProgress"/>
     <meta property="og:title" content="HRC Events Near You"/>
     <meta property="og:description" content="Find events and volunteer opportunities with the Clinton campaign in your area"/>
     <meta property="og:image" content="images/preview.png">
-    <!-- Link to mapzen.js script and stylesheets: -->
-    <link rel="stylesheet" href="https://mapzen.com/js/mapzen.css">
+    <link href='https://api.mapbox.com/mapbox.js/v2.4.0/mapbox.css' rel='stylesheet' />
     <link rel="stylesheet" href="css/jQRangeSlider-5.7.2/classic-min.css" />
-    <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico" />
-    <script src="https://mapzen.com/js/mapzen.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/0.5.0/leaflet.markercluster.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/0.5.0/MarkerCluster.css" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/0.5.0/MarkerCluster.Default.css" />
-    <script src="js/d3.v3.min.js"></script>
-    <script src="https://code.jquery.com/jquery-1.10.2.min.js"></script>
-    <script src="https://code.jquery.com/ui/1.10.3/jquery-ui.min.js"></script>
-    <script src="js/jQDateRangeSlider-withRuler-5.7.2.min.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/swipe/2.0/swipe.min.js"></script>
     <link rel="stylesheet" href="css/style.css">
   </head>
   <body>
@@ -114,6 +106,13 @@
       </div>
     </div>
 
+    <script src="https://code.jquery.com/jquery-1.10.2.min.js"></script>
+    <script src='https://api.mapbox.com/mapbox.js/v2.4.0/mapbox.js'></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/0.5.0/leaflet.markercluster.js"></script>
+    <script src="https://code.jquery.com/ui/1.10.3/jquery-ui.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/swipe/2.0/swipe.min.js"></script>
+    <script src="js/jQDateRangeSlider-withRuler-5.7.2.min.js"></script>
+    <script src="js/d3.v3.min.js"></script>
     <script src="js/underscore-min.js"></script>
     <script src="js/zipcode.js"></script>
     <script src="js/event-map.js"></script>

--- a/index.html
+++ b/index.html
@@ -112,7 +112,6 @@
     </div>
 
     <script src="js/underscore-min.js"></script>
-    <script src="js/zipcode.js"></script>
     <script src="js/event-map.js"></script>
     <script type="text/javascript">
       var e = eventsMap();

--- a/js/event-map.js
+++ b/js/event-map.js
@@ -32,6 +32,7 @@ var eventsMap = function() {
     minDate = new Date(),
     maxDate = new Date(minDate.getTime()+(28*1000*60*60*24)),
     setup = false,
+    cancelEventSearch = false,
     searchInput = 'search-input';
 
   var iso = d3.time.format.utc("%Y-%m-%dT%H:%M:%SZ"),
@@ -45,6 +46,9 @@ var eventsMap = function() {
       this.setUpEventHandlers();
       this.tryForAutoLocation();
       this.setUpDateSlider();
+      var script = document.createElement("script");
+      script.src = "js/zipcode.js";
+      document.getElementsByTagName("head")[0].appendChild(script);
     },
     setUpMap : function() {
       map = L.Mapzen.map('map', {
@@ -54,8 +58,12 @@ var eventsMap = function() {
       // disable default state to preference user location:
       // map.fitBounds([[48,-123], [28,-70]]);
 
-      map.on("moveend",function(){
+      map.on("moveend",function(ev){
         if (!eventsApp.moveUpdate()) return;
+        if (cancelEventSearch) {
+          cancelEventSearch = true;  // zoom next time
+          return;
+        }
         var meters = map.getBounds().getNorthEast().distanceTo(map.getBounds().getSouthWest()),
           miles = meters*0.000621371,
           center = map.getCenter();
@@ -148,14 +156,21 @@ var eventsMap = function() {
     tryForAutoLocation : function() {
       if (!navigator.geolocation) return;
       navigator.geolocation.getCurrentPosition(function(position) {
+          eventsApp.showMap(position.coords.latitude, position.coords.longitude, 10);
           searchedLocation = [position.coords.latitude, position.coords.longitude];
           eventsApp.doEventSearch(searchedLocation[0], searchedLocation[1], eventsApp.getRadius());
       }, function error(msg) {
-          //do nothing
+          eventsApp.showMap(39.833333, -98.583333, 3, true);
       },
       // if the browser has a cached location thats not more than one hour
       // old, we'll just use that to make the page go faster.
       {maximumAge: 1000 * 3600});
+    },
+    showMap: function(lat, lng, zoom, skipSearch) {
+      // setting the view will fire a moveend event
+      // we don't want to do an event search, with zoom to markers
+      cancelEventSearch = skipSearch;
+      map.setView(L.latLng(lat, lng), zoom);
     },
     setUpDateSlider: function() {
       var thisMonth = new Date();
@@ -552,7 +567,7 @@ var eventsMap = function() {
       d3.json("https://www.hillaryclinton.com/api/events/events?lat="+lat+"&lng="+lng+"&radius="+radius+"&earliestTime="+earliestTime+"&status=confirmed&visibility=public&perPage=500&onepage=1&_=1457303591599", function(error, json){
         allEvents = json.events;
         // uncomment to debug duplicates
-        /*var dupes = []
+        /*var dupes = [] []
         for (var e = 0; e < allEvents.length; e++) {
           if (allEvents[e].locations[0].name == 'Downtown Campaign Office' && allEvents[e].startDate.substring(0, 10) == '2016-08-29') {
             dupes.push(allEvents[e]);
@@ -562,6 +577,7 @@ var eventsMap = function() {
         // bump the radius until an event is found within 150mi
         if (allEvents.length < 1 && radius <= 150) {
           radius = radius*2;
+          console.log('too small - bumping to ' + radius + ' miles');
           eventsApp.doEventSearch(lat, lng, radius);
           return;
         }

--- a/js/event-map.js
+++ b/js/event-map.js
@@ -48,6 +48,7 @@ var eventsMap = function() {
       this.setUpDateSlider();
     },
     setUpMap : function() {
+      var ts = (new Date()).getTime();
       map = L.Mapzen.map('map', {
         scrollWheelZoom : false,
         scene : L.Mapzen.HouseStyles.Refill
@@ -67,8 +68,11 @@ var eventsMap = function() {
         searchedLocation = [center.lat, center.lng];
         eventsApp.doEventSearch(center.lat, center.lng, miles/2);
       });
+      map.on("load", function(event) {
+        console.log("load elapsed="+((new Date()).getTime()-ts));
+      });
       map.on("tangramloaded", function(event) {
-        console.log("tangramloaded");
+        console.log("tangramloaded elapsed="+((new Date()).getTime()-ts));
         if (document.getElementById("zipcode")) {
           return;  // already loaded
         }

--- a/js/event-map.js
+++ b/js/event-map.js
@@ -49,9 +49,10 @@ var eventsMap = function() {
     setUpMap : function() {
       var ts = (new Date()).getTime();
       L.mapbox.accessToken = 'pk.eyJ1IjoiaHJjLWV2ZW50cyIsImEiOiJjaXNxcnZ5aWgwMmE4MnRtMTBib2JoMWF2In0.yLt9Q6B-IZ2FFQ-KPg3rxg';
-
+      var layer = L.mapbox.tileLayer('mapbox.light');
       map = L.mapbox.map('map');
-      
+      map.addLayer(layer);
+
       L.mapbox.styleLayer('mapbox://styles/hrc-events/cisqrwrb300252xpj5ux74kr5').addTo(map);
       // disable default state to preference user location:
       map.setView([-80,40], 5);
@@ -67,8 +68,8 @@ var eventsMap = function() {
       map.on("load", function(event) {
         console.log("load elapsed="+((new Date()).getTime()-ts));
       });
-      map.on("tangramloaded", function(event) {
-        console.log("tangramloaded elapsed="+((new Date()).getTime()-ts));
+      layer.on("tileload", function(e) {
+        console.log("tileload elapsed="+((new Date()).getTime() - ts));
         if (document.getElementById("zipcode")) {
           return;  // already loaded
         }
@@ -76,7 +77,7 @@ var eventsMap = function() {
         script.src = "js/zipcode.js";
         script.id = "zipcode";
         document.getElementsByTagName("head")[0].appendChild(script);
-      });      
+      });
     },
     setUpEventHandlers : function() {
       d3.select("#radius-select").on("change",function(){

--- a/js/event-map.js
+++ b/js/event-map.js
@@ -46,9 +46,6 @@ var eventsMap = function() {
       this.setUpEventHandlers();
       this.tryForAutoLocation();
       this.setUpDateSlider();
-      var script = document.createElement("script");
-      script.src = "js/zipcode.js";
-      document.getElementsByTagName("head")[0].appendChild(script);
     },
     setUpMap : function() {
       map = L.Mapzen.map('map', {
@@ -70,6 +67,16 @@ var eventsMap = function() {
         searchedLocation = [center.lat, center.lng];
         eventsApp.doEventSearch(center.lat, center.lng, miles/2);
       });
+      map.on("tangramloaded", function(event) {
+        console.log("tangramloaded");
+        if (document.getElementById("zipcode")) {
+          return;  // already loaded
+        }
+        var script = document.createElement("script");
+        script.src = "js/zipcode.js";
+        script.id = "zipcode";
+        document.getElementsByTagName("head")[0].appendChild(script);
+      });      
     },
     setUpEventHandlers : function() {
       d3.select("#radius-select").on("change",function(){
@@ -154,7 +161,9 @@ var eventsMap = function() {
       return $('#move-update:visible').length === 0 || $('#move-update').is(':checked');
     },
     tryForAutoLocation : function() {
-      if (!navigator.geolocation) return;
+      if (!navigator.geolocation) {
+        return;
+      }
       navigator.geolocation.getCurrentPosition(function(position) {
           eventsApp.showMap(position.coords.latitude, position.coords.longitude, 10);
           searchedLocation = [position.coords.latitude, position.coords.longitude];

--- a/js/event-map.js
+++ b/js/event-map.js
@@ -33,7 +33,7 @@ var eventsMap = function() {
     setup = false,
     swipe = null,
     searchInput = 'search-input';
-
+    
   var iso = d3.time.format.utc("%Y-%m-%dT%H:%M:%SZ"),
     wholeDate = d3.time.format("%b %-d %-I:%M %p"),
     dateFormat = d3.time.format("%b %-d"),
@@ -47,12 +47,13 @@ var eventsMap = function() {
       this.setUpDateSlider();
     },
     setUpMap : function() {
-      map = L.Mapzen.map('map', {
-        scrollWheelZoom : false,
-        scene : L.Mapzen.HouseStyles.Refill
-      });
+      L.mapbox.accessToken = 'pk.eyJ1IjoiaHJjLWV2ZW50cyIsImEiOiJjaXNxcnZ5aWgwMmE4MnRtMTBib2JoMWF2In0.yLt9Q6B-IZ2FFQ-KPg3rxg';
+
+      map = L.mapbox.map('map');
+      
+      L.mapbox.styleLayer('mapbox://styles/hrc-events/cisqrwrb300252xpj5ux74kr5').addTo(map);
       // disable default state to preference user location:
-      // map.fitBounds([[48,-123], [28,-70]]);
+      map.setView([-80,40], 5);
 
       map.on("dragend",function(){
         if (!eventsApp.moveUpdate()) return;


### PR DESCRIPTION
- Load zip code data after rest of page has loaded
- Show map while loading event data, instead of after
- Show full US map without event search if browser autolocation unavailable.

for https://github.com/DevProgress/hrc-events/issues/59
